### PR TITLE
Better logging

### DIFF
--- a/cmd/cluster/datanode.go
+++ b/cmd/cluster/datanode.go
@@ -37,14 +37,16 @@ type dataNode struct {
 func makeDataNode(c net.Conn, id uint16, tel *telemetry.Telemetry, overHeadparam int64) *dataNode {
 	logger := slog.Default().With("node-id", id)
 	dataNode := &dataNode{
-		Conn:          c,
+		Conn: c,
+
 		id:            id,
 		avgRT:         0.0,
 		requests:      0,
 		overHeadParam: overHeadparam,
-		log:           logger,
-		tel:           tel,
-		mtx:           new(sync.Mutex),
+
+		log: logger,
+		tel: tel,
+		mtx: new(sync.Mutex),
 	}
 
 	return dataNode
@@ -98,6 +100,7 @@ func (d *dataNode) Listen(wg *sync.WaitGroup) {
 		timestamp:    time.Now(),
 		duration:     0,
 		size:         0,
+		avgRT:        d.avgRT,
 	})
 
 	d.log.Info(
@@ -147,6 +150,7 @@ func (d *dataNode) Listen(wg *sync.WaitGroup) {
 		timestamp:    time.Now(),
 		duration:     0,
 		size:         0,
+		avgRT:        d.avgRT,
 	})
 }
 
@@ -215,6 +219,7 @@ func (d *dataNode) handleUserJoin(buf []byte) error {
 		timestamp:    ts,
 		duration:     uint64(time.Since(ts).Nanoseconds()),
 		size:         uint64(n),
+		avgRT:        d.avgRT,
 	})
 
 	return nil
@@ -250,5 +255,6 @@ func (d *dataNode) healthCheckReport(srvStartTime *time.Time) {
 		timestamp:    ts,
 		duration:     uint64(time.Since(ts).Nanoseconds()),
 		size:         uint64(n),
+		avgRT:        d.avgRT,
 	})
 }

--- a/cmd/cluster/telemetry.go
+++ b/cmd/cluster/telemetry.go
@@ -30,6 +30,7 @@ var eventHeaders = []string{
 	"timestamp",
 	"duration(ns)",
 	"bytes-transferred",
+	"avgRT",
 }
 
 // telemetry
@@ -41,6 +42,7 @@ type event struct {
 	timestamp    time.Time
 	duration     uint64 // in nanoseconds
 	size         uint64 // in bytes
+	avgRT        float64
 }
 
 // Row implements telemetry.Record.
@@ -53,5 +55,6 @@ func (e *event) Row() []string {
 		fmt.Sprintf("%d", e.timestamp.UnixNano()),
 		fmt.Sprintf("%d", e.duration),
 		humanize.Bytes(e.size),
+		fmt.Sprintf("%f", e.avgRT),
 	}
 }

--- a/cmd/cluster/telemetry.go
+++ b/cmd/cluster/telemetry.go
@@ -30,7 +30,7 @@ var eventHeaders = []string{
 	"timestamp",
 	"duration(ns)",
 	"bytes-transferred",
-	"avgRT",
+	"avgRT(ns)",
 }
 
 // telemetry

--- a/cmd/loadbalance/clients.go
+++ b/cmd/loadbalance/clients.go
@@ -128,16 +128,7 @@ func (d *dataNode) handleHealthCheck(buf []byte) {
 	lbSrv.lock.Lock()
 
 	ts := time.Now()
-	defer func() {
-		lbSrv.lock.Unlock()
-		lbSrv.tel.Collect(&event{
-			eType:     eventHealthCheck,
-			peer:      peerDataNode,
-			peerID:    int32(d.id),
-			timestamp: ts,
-			duration:  time.Since(ts).Nanoseconds(),
-		})
-	}()
+	defer lbSrv.lock.Unlock()
 
 	// data node sends a health check message when it's done serving the client.
 	// so the active requests is reduced by 1.
@@ -154,6 +145,15 @@ func (d *dataNode) handleHealthCheck(buf []byte) {
 		d.log.Error("failed priority queue fixes.", "err", err)
 		return
 	}
+
+	lbSrv.tel.Collect(&event{
+		eType:     eventHealthCheck,
+		peer:      peerDataNode,
+		peerID:    int32(d.id),
+		timestamp: ts,
+		duration:  time.Since(ts).Nanoseconds(),
+		avgRT:     d.avgRT,
+	})
 }
 
 func (dn *dataNode) handlePortForward(buf []byte) {

--- a/cmd/loadbalance/lb.go
+++ b/cmd/loadbalance/lb.go
@@ -24,7 +24,7 @@ const (
 )
 
 var csvheaders = []string{
-	"event-type", "peer", "node-id", "timestamp", "duration(ns)", "avgRT",
+	"event-type", "peer", "node-id", "timestamp", "duration(ns)", "avgRT(ns)",
 }
 
 type event struct {

--- a/cmd/loadbalance/lb.go
+++ b/cmd/loadbalance/lb.go
@@ -24,7 +24,7 @@ const (
 )
 
 var csvheaders = []string{
-	"event-type", "peer", "node-id", "timestamp", "duration(ns)",
+	"event-type", "peer", "node-id", "timestamp", "duration(ns)", "avgRT",
 }
 
 type event struct {
@@ -33,6 +33,7 @@ type event struct {
 	peerID    int32
 	timestamp time.Time
 	duration  int64
+	avgRT     float64
 }
 
 func (e *event) Row() []string {
@@ -42,6 +43,7 @@ func (e *event) Row() []string {
 		fmt.Sprintf("%d", e.peerID),
 		fmt.Sprintf("%d", e.timestamp.UnixNano()),
 		fmt.Sprintf("%d", e.duration),
+		fmt.Sprintf("%f", e.avgRT),
 	}
 }
 
@@ -154,7 +156,9 @@ func (lb *loadBalancer) userJoinHandler(user net.Conn, buf []byte) error {
 		peerID:    int32(nodeQ.id),
 		timestamp: ts,
 		duration:  time.Since(ts).Nanoseconds(),
+		avgRT:     nodeQ.avgRT,
 	})
+
 	return err
 }
 
@@ -178,6 +182,8 @@ func (lb *loadBalancer) nodeJoinHandler(node net.Conn, msg []byte) error {
 		peerID:    int32(nodeId),
 		timestamp: ts,
 		duration:  time.Since(ts).Nanoseconds(),
+		avgRT:     dataNode.avgRT,
 	})
+
 	return nil
 }

--- a/cmd/loadbalance/lb.go
+++ b/cmd/loadbalance/lb.go
@@ -146,7 +146,6 @@ func (lb *loadBalancer) userJoinHandler(user net.Conn, buf []byte) error {
 
 	// port fowarding
 	nodeQ.write(buf[:])
-	cxMap.setClient(user) // TODO: may not need this
 
 	lb.engine.PutNode(nodeQ)
 

--- a/cmd/loadbalance/main.go
+++ b/cmd/loadbalance/main.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"log/slog"
 	"net"
+	"time"
 
 	"github.com/hn275/distributed-storage/internal"
 	"github.com/hn275/distributed-storage/internal/algo"
@@ -71,6 +72,7 @@ func main() {
 
 	// serving
 	lbSrv.listen()
+	time.Sleep(5 * time.Second)
 
 	// TODO: write telemetry data out
 	slog.Info("end of simulation")


### PR DESCRIPTION
I've added average response time of the associated node for each event in the load balancer and the cluster output csv files, the headers now include the columns `avgRT` at the end, and the events that matter would be `user-join` for lb when it's dispatching a node, and `health-check` (for both lb and cluster) for when it's sending/receiving the health check packet